### PR TITLE
Put outline layer under active layer

### DIFF
--- a/pistos-outline-text.py
+++ b/pistos-outline-text.py
@@ -22,7 +22,8 @@ def outline_text(image, layer, outline_size, layer_opacity) :
         layer_opacity,
         0
     )
-    pdb.gimp_image_insert_layer(image, new_layer, None, 1)
+    position = image.layers.index(layer)+1
+    pdb.gimp_image_insert_layer(image, new_layer, None, position)
 
     pdb.gimp_selection_feather(image, outline_size)
 


### PR DESCRIPTION
The original code works well when the active layer is the top layer, but this modification should take care of the case where the active text layer is in a different position (in the layer stack).