### PR TITLE
Outline is placed under active layer (Scheme)

### DIFF
--- a/pistos-outline-text.scm
+++ b/pistos-outline-text.scm
@@ -29,6 +29,7 @@
       (colour -1)
       (activeLayer -1)
       (newLayer -1)
+      (layerPosUnder -1)
     )
 
     (gimp-undo-push-group-start image)
@@ -58,8 +59,12 @@
         0
       ))
     )
+	
+	(set! layerPosUnder
+	  (+ (car(gimp-image-get-layer-position image activeLayer)) 1)
+	)
 
-    (gimp-image-insert-layer image newLayer -1 1)
+    (gimp-image-insert-layer image newLayer -1 layerPosUnder)
     (gimp-selection-feather image outlineSize)
     (gimp-edit-fill newLayer BACKGROUND-FILL)
     (gimp-selection-none image)


### PR DESCRIPTION
I saw another similar pull request for the same feature, however that pull request was created back when the script was written in Python. This is a similar pull request, but for the Scheme version of the script.

I do admit I'm not familiar with Scheme, so this was a trial-and-error contribution, but it does work in it's current state.